### PR TITLE
Use Skypack CDN

### DIFF
--- a/docs/_layouts/segmented.html
+++ b/docs/_layouts/segmented.html
@@ -59,7 +59,6 @@ layout: default
 <script src="https://unpkg.com/vue@3.2.31/dist/vue.global.js"></script>
 {% endif %}
 <script src="https://unpkg.com/opentype.js@1.3.4/dist/opentype.min.js"></script>
-<script src="https://unpkg.com/raphael@2.3.0/raphael.min.js"></script>
 
 <script type="module">
   import App from '{{ site.baseurl }}/assets/js/components/App.js'

--- a/docs/_layouts/segmented.html
+++ b/docs/_layouts/segmented.html
@@ -58,7 +58,6 @@ layout: default
 {% else %}
 <script src="https://unpkg.com/vue@3.2.31/dist/vue.global.js"></script>
 {% endif %}
-<script src="https://unpkg.com/opentype.js@1.3.4/dist/opentype.min.js"></script>
 
 <script type="module">
   import App from '{{ site.baseurl }}/assets/js/components/App.js'

--- a/docs/_layouts/segmented.html
+++ b/docs/_layouts/segmented.html
@@ -59,7 +59,6 @@ layout: default
 <script src="https://unpkg.com/vue@3.2.31/dist/vue.global.js"></script>
 {% endif %}
 <script src="https://unpkg.com/opentype.js@1.3.4/dist/opentype.min.js"></script>
-<script src="https://unpkg.com/jsts@2.3.0/dist/jsts.min.js"></script>
 <script src="https://unpkg.com/raphael@2.3.0/raphael.min.js"></script>
 
 <script type="module">

--- a/docs/assets/js/Stencil.js
+++ b/docs/assets/js/Stencil.js
@@ -1,5 +1,5 @@
-import opentype from 'https://cdn.skypack.dev/opentype.js@1.3.4';
-import jsts from 'https://cdn.skypack.dev/jsts@2.3.0';
+import {opentype, jsts} from './upstream.js';
+
 
 const reader = new jsts.io.GeoJSONReader();
 

--- a/docs/assets/js/Stencil.js
+++ b/docs/assets/js/Stencil.js
@@ -1,4 +1,4 @@
-
+import opentype from 'https://cdn.skypack.dev/opentype.js@1.3.4';
 import jsts from 'https://cdn.skypack.dev/jsts@2.3.0';
 
 const reader = new jsts.io.GeoJSONReader();

--- a/docs/assets/js/Stencil.js
+++ b/docs/assets/js/Stencil.js
@@ -1,3 +1,6 @@
+
+import jsts from 'https://cdn.skypack.dev/jsts@2.3.0';
+
 const reader = new jsts.io.GeoJSONReader();
 
 function pairsToGeom(pairs) {

--- a/docs/assets/js/components/StencilEditor.js
+++ b/docs/assets/js/components/StencilEditor.js
@@ -1,3 +1,5 @@
+import Raphael from 'https://cdn.skypack.dev/raphael@2.3.0';
+
 import { drawSegment } from "../svgHelper.js";
 
 export default {

--- a/docs/assets/js/components/StencilEditor.js
+++ b/docs/assets/js/components/StencilEditor.js
@@ -1,4 +1,4 @@
-import Raphael from 'https://cdn.skypack.dev/raphael@2.3.0';
+import { Raphael } from '../upstream.js';
 
 import { drawSegment } from "../svgHelper.js";
 

--- a/docs/assets/js/fontHelper.js
+++ b/docs/assets/js/fontHelper.js
@@ -1,4 +1,4 @@
-import opentype from 'https://cdn.skypack.dev/opentype.js@1.3.4';
+import {opentype} from './upstream.js';
 
 import Stencil from './Stencil.js';
 

--- a/docs/assets/js/fontHelper.js
+++ b/docs/assets/js/fontHelper.js
@@ -1,3 +1,5 @@
+import opentype from 'https://cdn.skypack.dev/opentype.js@1.3.4';
+
 import Stencil from './Stencil.js';
 
 function makeGlyph(character, path) {

--- a/docs/assets/js/upstream.js
+++ b/docs/assets/js/upstream.js
@@ -1,6 +1,10 @@
-// List all external dependencies here.
+// List external dependencies here.
 // - If we need to move to a different CDN, it's all in one place.
 // - Individual files don't need to track the version we're using.
+//
+// Vue is an exception: We want a different version in development and production,
+// and I'm not sure how to get that conditionality in here without breaking mocha,
+// so it's still pulled in as global in the HTML.
 
 export {default as Raphael} from 'https://cdn.skypack.dev/raphael@2.3.0';
 export {default as opentype} from 'https://cdn.skypack.dev/opentype.js@1.3.4';

--- a/docs/assets/js/upstream.js
+++ b/docs/assets/js/upstream.js
@@ -1,0 +1,7 @@
+// List all external dependencies here.
+// - If we need to move to a different CDN, it's all in one place.
+// - Individual files don't need to track the version we're using.
+
+export {default as Raphael} from 'https://cdn.skypack.dev/raphael@2.3.0';
+export {default as opentype} from 'https://cdn.skypack.dev/opentype.js@1.3.4';
+export {default as jsts} from 'https://cdn.skypack.dev/jsts@2.3.0';


### PR DESCRIPTION
Getting away from globals is a good thing, period. (Vue is still a TODO: perhaps have upstream.js processed by Jekyll?) I had hoped that once the dependencies were ESM imports testing would be easier, but I'm still running into roadblocks there. (Lack of support for ESM in node, errors when trying to run tests in browser...)

But just this much is also useful.